### PR TITLE
WIP: Add Calendar Events in emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"core-decorators": "^0.20.0",
 				"eventemitter3": "^4.0.7",
 				"fuzzysort": "^2.0.1",
+				"ical-js-parser": "^0.7.0",
 				"mobx": "^6.5.0",
 				"mobx-react": "^7.4.0",
 				"react": "^17.0.2",
@@ -12427,6 +12428,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/ical-js-parser": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/ical-js-parser/-/ical-js-parser-0.7.0.tgz",
+			"integrity": "sha512-oKxIw7yZLvZd/hFf0c8idHVJXBTSz3xj8QPvH3KuHncO0SMfuYzLXXZB4aZLS+5ZMh4h0bgErhBDjtksKaH1Ng==",
+			"dependencies": {
+				"luxon": "3.0.3"
+			}
+		},
+		"node_modules/ical-js-parser/node_modules/luxon": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.3.tgz",
+			"integrity": "sha512-+EfHWnF+UT7GgTnq5zXg3ldnTKL2zdv7QJgsU5bjjpbH17E3qi/puMhQyJVYuCq+FRkogvB5WB6iVvUr+E4a7w==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -34486,6 +34503,21 @@
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true
+		},
+		"ical-js-parser": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/ical-js-parser/-/ical-js-parser-0.7.0.tgz",
+			"integrity": "sha512-oKxIw7yZLvZd/hFf0c8idHVJXBTSz3xj8QPvH3KuHncO0SMfuYzLXXZB4aZLS+5ZMh4h0bgErhBDjtksKaH1Ng==",
+			"requires": {
+				"luxon": "3.0.3"
+			},
+			"dependencies": {
+				"luxon": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.3.tgz",
+					"integrity": "sha512-+EfHWnF+UT7GgTnq5zXg3ldnTKL2zdv7QJgsU5bjjpbH17E3qi/puMhQyJVYuCq+FRkogvB5WB6iVvUr+E4a7w=="
+				}
+			}
 		},
 		"iconv-lite": {
 			"version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"core-decorators": "^0.20.0",
 		"eventemitter3": "^4.0.7",
 		"fuzzysort": "^2.0.1",
+		"ical-js-parser": "^0.7.0",
 		"mobx": "^6.5.0",
 		"mobx-react": "^7.4.0",
 		"react": "^17.0.2",

--- a/src/assets/scss/base/buttons.scss
+++ b/src/assets/scss/base/buttons.scss
@@ -238,7 +238,7 @@ button:focus {
 }
 
 .btn-link {
-  color: inherit;
+  color: $navy;
 }
 
 .btn-link:hover, .btn-link:focus, .btn-link:active, .btn-link.active, .open .dropdown-toggle.btn-link {

--- a/src/assets/scss/base/pages.scss
+++ b/src/assets/scss/base/pages.scss
@@ -614,6 +614,45 @@ a.compose-mail {
 	margin-right: 5px;
 }
 
+/* EVENTBOX */
+
+.event-box {
+	background-color: #ffffff;
+	border: 1px solid $border-color;
+	padding: 20px;
+	border-bottom: 0;
+}
+
+.event-box-details {
+	display: flex;
+	flex-direction: row;
+	gap: 20px;
+	padding-top: 12px;
+}
+
+.event-box-details-part {
+	display: flex;
+	flex-direction: row;
+	gap: 10px;
+}
+
+.event-box-details-labels {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	opacity: 0.6;
+}
+
+.event-box-details-values {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+
+.event-box-description {
+	padding-top: 5px;
+}
+
 /* MAILBOX */
 
 .mail-box {

--- a/src/assets/scss/base/pages.scss
+++ b/src/assets/scss/base/pages.scss
@@ -634,6 +634,10 @@ a.compose-mail {
 		padding-bottom: 5px;
 		padding-right: 5px;
 	}
+	
+	td:nth-child(even) {
+		padding-right: 15px;
+	}
 }
 
 .event-box-label {

--- a/src/assets/scss/base/pages.scss
+++ b/src/assets/scss/base/pages.scss
@@ -628,29 +628,17 @@ a.compose-mail {
 	flex-direction: row;
 	gap: 20px;
 	padding-top: 12px;
+
+	td {
+		vertical-align: top;
+		padding-bottom: 5px;
+		padding-right: 5px;
+	}
 }
 
-.event-box-details-part {
-	display: flex;
-	flex-direction: row;
-	gap: 10px;
-}
-
-.event-box-details-labels {
-	display: flex;
-	flex-direction: column;
+.event-box-label {
 	gap: 5px;
 	opacity: 0.6;
-}
-
-.event-box-details-values {
-	display: flex;
-	flex-direction: column;
-	gap: 5px;
-}
-
-.event-box-description {
-	padding-top: 5px;
 }
 
 /* MAILBOX */

--- a/src/components/CollapsedText/CollapsedText.tsx
+++ b/src/components/CollapsedText/CollapsedText.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+const CollapsedText = ({ text, collapseCount }: { text: string, collapseCount: number }) => {
+    const [isCollapsed, setIsCollapsed] = useState(true);
+
+    if (text.length <= collapseCount) {
+        return <p>{text}</p>;
+    }
+
+    const actionText = isCollapsed ? 'Show More' : 'Show Less';
+    const displayText = isCollapsed ? `${text.slice(0, collapseCount)}...` : text;
+
+    const handleAction = () => {
+        setIsCollapsed(!isCollapsed);
+    }
+
+    return (
+        <p>
+            {displayText}
+            <button style={{ padding: '0 3px' }} type="button" className="btn btn-link" onClick={handleAction}>
+                {actionText}
+            </button>
+        </p>
+    );
+};
+
+export default CollapsedText;

--- a/src/components/smallButton/smallButton.tsx
+++ b/src/components/smallButton/smallButton.tsx
@@ -19,6 +19,7 @@ export enum smallButtonIcons {
 	restore = 'fa-rotate-left',
 	forward = 'fa-arrow-right',
 	arrowLeft = 'fa-arrow-left',
+	calendar = 'fa-calendar',
 }
 
 interface SmallButtonProps {

--- a/src/pages/ComposePage/components/MailMeta.scss
+++ b/src/pages/ComposePage/components/MailMeta.scss
@@ -1,0 +1,3 @@
+.mail-meta {
+    padding-bottom: 15px;
+}

--- a/src/pages/ComposePage/components/MailMeta.tsx
+++ b/src/pages/ComposePage/components/MailMeta.tsx
@@ -4,6 +4,7 @@ import { PureComponent } from 'react';
 import { RecipientsSelect } from '../../../controls/RecipientSelect';
 import domain from '../../../stores/Domain';
 import mailbox from '../../../stores/Mailbox';
+import './MailMeta.scss'
 
 @observer
 export class MailMeta extends PureComponent {
@@ -15,7 +16,7 @@ export class MailMeta extends PureComponent {
 
 	render() {
 		return (
-			<>
+			<div className='mail-meta'>
 				<div className="form-group row">
 					<label className="col-sm-1 col-form-label">From:</label>
 					<div className="col-sm-11" style={{ position: 'relative', zIndex: 2 }}>
@@ -52,7 +53,7 @@ export class MailMeta extends PureComponent {
 						/>
 					</div>
 				</div>
-			</>
+			</div>
 		);
 	}
 }

--- a/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.scss
+++ b/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.scss
@@ -1,0 +1,26 @@
+button span {
+    margin-left: 3px;
+}
+
+.add-event-btn {
+    position: absolute;
+    transform: translateY(-50%);
+    margin-left: 15px;
+}
+
+.mailbox-editor-secion {
+    padding: 0px;
+}
+
+.add-event-section {
+    transition: height 0.2s linear;
+    overflow: hidden;
+
+    &.inactive {
+        border: none;
+    }
+
+    .add-event-section-content {
+        padding: 35px 15px;
+    }
+}

--- a/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
@@ -3,10 +3,22 @@ import './MailboxCalendarEventEditor.scss';
 import SmallButton, { smallButtonColors, smallButtonIcons } from '../../../../../components/smallButton/smallButton';
 import { observer } from 'mobx-react';
 import { useRef } from 'react';
+import { DatePicker } from 'antd';
+import { RangePickerProps } from 'antd/lib/date-picker';
 
 const MailboxCalendarEventEditor = observer(() => {
     const eventSectionRef = useRef<HTMLDivElement>(null);
     const calculatedHeight = useRef(0);
+
+    const onOk = (value: RangePickerProps['value']) => {
+        if (value) {
+            const [start, end] = value;
+            if (start && end) {
+                mailbox.event.start = start.toDate();
+                mailbox.event.end = end.toDate();
+            }
+        }
+    }
 
     return (
         <>
@@ -36,6 +48,17 @@ const MailboxCalendarEventEditor = observer(() => {
                         </div>
                     </div>
                     <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">When:</label>
+                        <div className="col-sm-11">
+                            <DatePicker.RangePicker
+                                showTime={{ format: 'HH:mm' }}
+                                format="YYYY-MM-DD HH:mm"
+                                minuteStep={5}
+                                onOk={onOk}
+                            />
+                        </div>
+                    </div>
+                    <div className="form-group row">
                         <label className="col-sm-1 col-form-label">Location:</label>
                         <div className="col-sm-11">
                             <input
@@ -43,30 +66,6 @@ const MailboxCalendarEventEditor = observer(() => {
                                 className="form-control"
                                 value={mailbox.event.location}
                                 onChange={e => (mailbox.event.location = e.target.value)}
-                            />
-                        </div>
-                    </div>
-                    <div className="form-group row">
-                        <label className="col-sm-1 col-form-label">Start:</label>
-                        <div className="col-sm-11">
-                            <input
-                                type="datetime-local"
-                                className="form-control"
-                                value={mailbox.event.startDateTime}
-                                onChange={e => (mailbox.event.startDateTime = e.target.value)}
-                                max={mailbox.event.endDateTime}
-                            />
-                        </div>
-                    </div>
-                    <div className="form-group row">
-                        <label className="col-sm-1 col-form-label">End:</label>
-                        <div className="col-sm-11">
-                            <input
-                                type="datetime-local"
-                                className="form-control"
-                                value={mailbox.event.endDateTime}
-                                onChange={e => (mailbox.event.endDateTime = e.target.value)}
-                                min={mailbox.event.startDateTime}
                             />
                         </div>
                     </div>

--- a/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
@@ -54,6 +54,7 @@ const MailboxCalendarEventEditor = observer(() => {
                                 className="form-control"
                                 value={mailbox.event.startDateTime}
                                 onChange={e => (mailbox.event.startDateTime = e.target.value)}
+                                max={mailbox.event.endDateTime}
                             />
                         </div>
                     </div>
@@ -65,6 +66,7 @@ const MailboxCalendarEventEditor = observer(() => {
                                 className="form-control"
                                 value={mailbox.event.endDateTime}
                                 onChange={e => (mailbox.event.endDateTime = e.target.value)}
+                                min={mailbox.event.startDateTime}
                             />
                         </div>
                     </div>

--- a/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxCalendarEventEditor/MailboxCalendarEventEditor.tsx
@@ -1,0 +1,87 @@
+import mailbox from '../../../../../stores/Mailbox';
+import './MailboxCalendarEventEditor.scss';
+import SmallButton, { smallButtonColors, smallButtonIcons } from '../../../../../components/smallButton/smallButton';
+import { observer } from 'mobx-react';
+import { useRef } from 'react';
+
+const MailboxCalendarEventEditor = observer(() => {
+    const eventSectionRef = useRef<HTMLDivElement>(null);
+    const calculatedHeight = useRef(0);
+
+    return (
+        <>
+            <div className='add-event-btn'>
+                <SmallButton
+                    onClick={() => {
+                        calculatedHeight.current = eventSectionRef.current?.clientHeight || 0;
+                        mailbox.event.active = !mailbox.event.active
+                    }}
+                    text={mailbox.event.active ? 'Remove Event' : 'Add Event'}
+                    color={smallButtonColors.green}
+                    title={mailbox.event.active ? 'Remove Calendar Event' : 'Add Calendar Event'}
+                    icon={mailbox.event.active ? smallButtonIcons.cross : smallButtonIcons.calendar}
+                />
+            </div>
+            <div style={{ height: mailbox.event.active ? `${calculatedHeight.current}px` : '0px' }} className={`add-event-section ${!mailbox.event.active && 'inactive'}`}>
+                <div className='add-event-section-content' ref={eventSectionRef}>
+                    <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">Summary:</label>
+                        <div className="col-sm-11">
+                            <input
+                                type="text"
+                                className="form-control"
+                                value={mailbox.event.summary}
+                                onChange={e => (mailbox.event.summary = e.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">Location:</label>
+                        <div className="col-sm-11">
+                            <input
+                                type="text"
+                                className="form-control"
+                                value={mailbox.event.location}
+                                onChange={e => (mailbox.event.location = e.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">Start:</label>
+                        <div className="col-sm-11">
+                            <input
+                                type="datetime-local"
+                                className="form-control"
+                                value={mailbox.event.startDateTime}
+                                onChange={e => (mailbox.event.startDateTime = e.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">End:</label>
+                        <div className="col-sm-11">
+                            <input
+                                type="datetime-local"
+                                className="form-control"
+                                value={mailbox.event.endDateTime}
+                                onChange={e => (mailbox.event.endDateTime = e.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <div className="form-group row">
+                        <label className="col-sm-1 col-form-label">Description:</label>
+                        <div className="col-sm-11">
+                            <textarea
+                                className="form-control"
+                                value={mailbox.event.description}
+                                onChange={e => (mailbox.event.description = e.target.value)}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+});
+
+export default MailboxCalendarEventEditor;

--- a/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.scss
+++ b/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.scss
@@ -2,3 +2,10 @@
 .ce-toolbar__content {
   max-width: 85%;
 }
+
+.mailbox-editor {
+  .mailbox-editor-secion {
+    padding: 35px 15px 0;
+    border: 1px solid #e0e0e0;
+  }
+}

--- a/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
@@ -3,6 +3,7 @@ import { createReactEditorJS } from 'react-editor-js';
 import mailbox from '../../../../../stores/Mailbox';
 import './MailboxEditor.scss';
 import { EDITOR_JS_TOOLS } from '../../../../../utils/editorJs';
+import MailboxCalendarEventEditor from '../MailboxCalendarEventEditor/MailboxCalendarEventEditor';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -27,74 +28,10 @@ const MailboxEditor = () => {
 	}
 
 	return (
-		<>
-			<div
-				style={{
-					padding: '25px 15px 0',
-					border: '1px solid #e0e0e0',
-				}}
-			>
-				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">Summary:</label>
-					<div className="col-sm-11">
-						<input
-							type="text"
-							className="form-control"
-							value={mailbox.event.summary}
-							onChange={e => (mailbox.event.summary = e.target.value)}
-						/>
-					</div>
-				</div>
-				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">Location:</label>
-					<div className="col-sm-11">
-						<input
-							type="text"
-							className="form-control"
-							value={mailbox.event.location}
-							onChange={e => (mailbox.event.location = e.target.value)}
-						/>
-					</div>
-				</div>
-				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">Start:</label>
-					<div className="col-sm-11">
-						<input
-							type="datetime-local"
-							className="form-control"
-							value={mailbox.event.startDateTime}
-							onChange={e => (mailbox.event.startDateTime = e.target.value)}
-						/>
-					</div>
-				</div>
-				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">End:</label>
-					<div className="col-sm-11">
-						<input
-							type="datetime-local"
-							className="form-control"
-							value={mailbox.event.endDateTime}
-							onChange={e => (mailbox.event.endDateTime = e.target.value)}
-						/>
-					</div>
-				</div>
-				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">Description:</label>
-					<div className="col-sm-11">
-						<textarea
-							className="form-control"
-							value={mailbox.event.description}
-							onChange={e => (mailbox.event.description = e.target.value)}
-						/>
-					</div>
-				</div>
-			</div>
-			<div
-				style={{
-					padding: '25px 15px 0',
-					border: '1px solid #e0e0e0',
-				}}
-			>
+		<div className='mailbox-editor'>
+			
+			<MailboxCalendarEventEditor />
+			<div className='mailbox-editor-secion'>
 				<ReactEditorJS
 					tools={EDITOR_JS_TOOLS}
 					//@ts-ignore
@@ -106,7 +43,7 @@ const MailboxEditor = () => {
 					}}
 				/>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
@@ -27,23 +27,75 @@ const MailboxEditor = () => {
 	}
 
 	return (
-		<div
-			style={{
-				padding: '25px 15px 0',
-				border: '1px solid #e0e0e0',
-			}}
-		>
-			<ReactEditorJS
-				tools={EDITOR_JS_TOOLS}
-				//@ts-ignore
-				data={initialTextData}
-				onChange={handleSave}
-				instanceRef={(instance: any) => (instanceRef.current = instance)}
-				onInitialize={(instance: any) => {
-					instanceRef.current = instance;
+		<>
+			<div
+				style={{
+					padding: '25px 15px 0',
+					border: '1px solid #e0e0e0',
 				}}
-			/>
-		</div>
+			>
+				<div className="form-group row">
+					<label className="col-sm-1 col-form-label">Summary:</label>
+					<div className="col-sm-11">
+						<input
+							type="text"
+							className="form-control"
+							value={mailbox.event.summary}
+							onChange={e => (mailbox.event.summary = e.target.value)}
+						/>
+					</div>
+				</div>
+				<div className="form-group row">
+					<label className="col-sm-1 col-form-label">Start:</label>
+					<div className="col-sm-11">
+						<input
+							type="text"
+							className="form-control"
+							value={mailbox.event.startDateTime}
+							onChange={e => (mailbox.event.startDateTime = e.target.value)}
+						/>
+					</div>
+				</div>
+				<div className="form-group row">
+					<label className="col-sm-1 col-form-label">End:</label>
+					<div className="col-sm-11">
+						<input
+							type="text"
+							className="form-control"
+							value={mailbox.event.endDateTime}
+							onChange={e => (mailbox.event.endDateTime = e.target.value)}
+						/>
+					</div>
+				</div>
+				<div className="form-group row">
+					<label className="col-sm-1 col-form-label">Description:</label>
+					<div className="col-sm-11">
+						<textarea
+							className="form-control"
+							value={mailbox.event.description}
+							onChange={e => (mailbox.event.description = e.target.value)}
+						/>
+					</div>
+				</div>
+			</div>
+			<div
+				style={{
+					padding: '25px 15px 0',
+					border: '1px solid #e0e0e0',
+				}}
+			>
+				<ReactEditorJS
+					tools={EDITOR_JS_TOOLS}
+					//@ts-ignore
+					data={initialTextData}
+					onChange={handleSave}
+					instanceRef={(instance: any) => (instanceRef.current = instance)}
+					onInitialize={(instance: any) => {
+						instanceRef.current = instance;
+					}}
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
+++ b/src/pages/ComposePage/components/Mailbox/MailboxEditor/MailboxEditor.tsx
@@ -46,10 +46,21 @@ const MailboxEditor = () => {
 					</div>
 				</div>
 				<div className="form-group row">
-					<label className="col-sm-1 col-form-label">Start:</label>
+					<label className="col-sm-1 col-form-label">Location:</label>
 					<div className="col-sm-11">
 						<input
 							type="text"
+							className="form-control"
+							value={mailbox.event.location}
+							onChange={e => (mailbox.event.location = e.target.value)}
+						/>
+					</div>
+				</div>
+				<div className="form-group row">
+					<label className="col-sm-1 col-form-label">Start:</label>
+					<div className="col-sm-11">
+						<input
+							type="datetime-local"
 							className="form-control"
 							value={mailbox.event.startDateTime}
 							onChange={e => (mailbox.event.startDateTime = e.target.value)}
@@ -60,7 +71,7 @@ const MailboxEditor = () => {
 					<label className="col-sm-1 col-form-label">End:</label>
 					<div className="col-sm-11">
 						<input
-							type="text"
+							type="datetime-local"
 							className="form-control"
 							value={mailbox.event.endDateTime}
 							onChange={e => (mailbox.event.endDateTime = e.target.value)}

--- a/src/pages/ComposePage/components/Mailbox/tooltip.tsx
+++ b/src/pages/ComposePage/components/Mailbox/tooltip.tsx
@@ -120,7 +120,7 @@ const Tooltip = observer(() => {
 
 				if (payload.blocks && Array.isArray(payload.blocks)) {
 					payload.blocks.push({
-						type: "paragraph",
+						type: "calendarEvent",
 						data: {
 							text: eventBlockText
 						}

--- a/src/pages/ComposePage/components/Mailbox/tooltip.tsx
+++ b/src/pages/ComposePage/components/Mailbox/tooltip.tsx
@@ -107,12 +107,12 @@ const Tooltip = observer(() => {
 
 			const payload = mailbox.textEditorData;
 
-			if (mailbox.event.active && mailbox.event.startDateTime && mailbox.event.endDateTime) {
+			if (mailbox.event.active && mailbox.event.start && mailbox.event.end) {
 				const eventBlockText = createEventFileString({
 					organizer: mailbox.from?.account.address || '',
 					attendees: mailbox.to.map(toAddress => toAddress.address).filter(i => i) as string[],
-					startDateTime: new Date(mailbox.event.startDateTime),
-					endDateTime: new Date(mailbox.event.endDateTime),
+					start: mailbox.event.start,
+					end: mailbox.event.end,
 					summary: mailbox.event.summary || '',
 					locaiton: mailbox.event.location || '',
 					description: mailbox.event.description || '',
@@ -145,7 +145,7 @@ const Tooltip = observer(() => {
 		}
 	};
 
-	const validCalendarEvent = !mailbox.event.active || isValidCalendarEventDates(mailbox.event.startDateTime, mailbox.event.endDateTime);
+	const validCalendarEvent = !mailbox.event.active || isValidCalendarEventDates(mailbox.event.start, mailbox.event.end);
 
 	return (
 		<div

--- a/src/pages/ComposePage/components/Mailbox/tooltip.tsx
+++ b/src/pages/ComposePage/components/Mailbox/tooltip.tsx
@@ -106,7 +106,7 @@ const Tooltip = observer(() => {
 
 			const payload = mailbox.textEditorData;
 
-			if (mailbox.event.startDateTime && mailbox.event.endDateTime) {
+			if (mailbox.event.active && mailbox.event.startDateTime && mailbox.event.endDateTime) {
 				const eventBlockText = createEventFileString({
 					organizer: mailbox.from?.account.address || '',
 					attendees: mailbox.to.map(toAddress => toAddress.address).filter(i => i) as string[],

--- a/src/pages/ComposePage/components/Mailbox/tooltip.tsx
+++ b/src/pages/ComposePage/components/Mailbox/tooltip.tsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import { Dropdown, Menu } from 'antd';
 import mailList from '../../../../stores/MailList';
 import { createEventFileString } from '../../../../utils/eventFileString';
+import { isValidCalendarEventDates } from '../../../../utils/calendarEventDate';
 
 const evmNetworks = (Object.keys(EVM_NAMES) as unknown as EVMNetwork[]).map((network: EVMNetwork) => ({
 	name: EVM_NAMES[network],
@@ -144,6 +145,8 @@ const Tooltip = observer(() => {
 		}
 	};
 
+	const validCalendarEvent = !mailbox.event.active || isValidCalendarEventDates(mailbox.event.startDateTime, mailbox.event.endDateTime);
+
 	return (
 		<div
 			className="mail-body text-right tooltip-demo"
@@ -161,7 +164,8 @@ const Tooltip = observer(() => {
 						mailer.sending ||
 						!mailbox.to.some(r => r.isAchievable) ||
 						!mailbox.textEditorData?.blocks?.length ||
-						!mailbox.to.length,
+						!mailbox.to.length ||
+						!validCalendarEvent,
 					withDropdown: mailbox.from?.wallet.factory.blockchainGroup === 'evm',
 				})}
 			>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -131,6 +131,41 @@ const MailDetail = observer(() => {
 						</h5>
 					</div>
 				</div>
+				<div className='event-box'>
+					<h3 className='font-bold'>
+						Event Name
+					</h3>
+					<div className='event-box-details'>
+						<div className='event-box-details-part'>
+							<div className='event-box-details-labels font-bold'>
+								<div>Start</div>
+								<div>End</div>
+							</div>
+							<div className='event-box-details-values'>
+								<div>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</div>
+								<div>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</div>
+							</div>
+						</div>
+						<div className='event-box-details-part'>
+							<div className='event-box-details-labels font-bold'>
+								<div>Where</div>
+								<div>Who</div>
+							</div>
+							<div className='event-box-details-values'>
+								<div>Somewhere</div>
+								<div>Someone</div>
+							</div>
+						</div>
+					</div>
+					<div className='event-box-details-part event-box-description'>
+						<div className='event-box-details-labels font-bold'>
+							<div>Description</div>
+						</div>
+						<div className='event-box-details-values'>
+							<div>This is another desc.</div>
+						</div>
+					</div>
+				</div>
 				<div className="mail-box">
 					<div className="mail-body" style={{ minHeight: 370 }}>
 						{data.blocks ? (

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -136,34 +136,30 @@ const MailDetail = observer(() => {
 						Event Name
 					</h3>
 					<div className='event-box-details'>
-						<div className='event-box-details-part'>
-							<div className='event-box-details-labels font-bold'>
-								<div>Start</div>
-								<div>End</div>
-							</div>
-							<div className='event-box-details-values'>
-								<div>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</div>
-								<div>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</div>
-							</div>
-						</div>
-						<div className='event-box-details-part'>
-							<div className='event-box-details-labels font-bold'>
-								<div>Where</div>
-								<div>Who</div>
-							</div>
-							<div className='event-box-details-values'>
-								<div>Somewhere</div>
-								<div>Someone</div>
-							</div>
-						</div>
-					</div>
-					<div className='event-box-details-part event-box-description'>
-						<div className='event-box-details-labels font-bold'>
-							<div>Description</div>
-						</div>
-						<div className='event-box-details-values'>
-							<div>This is another desc.</div>
-						</div>
+						<table>
+							<tbody>
+								<tr>
+									<td className='event-box-label font-bold'>Start</td>
+									<td>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</td>
+									<td className='event-box-label font-bold'>End</td>
+									<td>Tue Nov 1 3am - Tue Nov 01, 2022 2:45am (AST)</td>
+								</tr>
+								<tr>
+									<td className='event-box-label font-bold'>Where</td>
+									<td>Somewhere</td>
+									<td className='event-box-label font-bold'>Who</td>
+									<td>Someone</td>
+								</tr>
+								<tr>
+									<td className='event-box-label font-bold'>Event File</td>
+									<td colSpan={3}>filename.ics</td>
+								</tr>
+								<tr>
+									<td className='event-box-label font-bold'>Description</td>
+									<td colSpan={3}>This is another desc. This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.This is another desc.</td>
+								</tr>
+							</tbody>
+						</table>
 					</div>
 				</div>
 				<div className="mail-box">

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -165,7 +165,7 @@ const MailDetail = observer(() => {
 					<h3 className='font-bold'>
 						<span style={{ verticalAlign: 'bottom' }}>
 							<CalendarOutlined style={{ fontSize: '22px' }} />
-						</span> Event Name
+						</span> {eventData?.events[0].summary}
 					</h3>
 					<div className='event-box-details'>
 						<table>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -13,7 +13,7 @@ import moment from 'moment';
 import mailList from '../stores/MailList';
 import { IMessageDecodedContent } from '../indexedDB/MessagesDB';
 import { CalendarOutlined } from '@ant-design/icons';
-import { isEventFileString, parseEventFileString } from '../utils/eventFileString';
+import { parseEventFileString } from '../utils/eventFileString';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -58,8 +58,9 @@ const MailDetail = observer(() => {
 		}
 
 		const eventFileBlockIndex = rawData.blocks.findIndex((item: { data: { text: string }, type: string }) => {
-			if (item.type !== "paragraph") return false;
-			return isEventFileString(item.data.text);
+			return item.type === 'calendarEvent';
+			// if (item.type !== "paragraph") return false;
+			// return isEventFileString(item.data.text);
 		});
 
 		if (eventFileBlockIndex < 0) {
@@ -167,7 +168,7 @@ const MailDetail = observer(() => {
 							<CalendarOutlined style={{ fontSize: '22px' }} />
 						</span> {eventData?.summary}
 					</h3>
-					<a href={downloadUrl} target={'_blank'} download={'invite.ics'}>Download invite</a>
+					<a href={downloadUrl} rel="noreferrer noopener" target={'_blank'} download={'invite.ics'}>Download invite</a>
 					<div className='event-box-details'>
 						<table>
 							<tbody>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -12,6 +12,7 @@ import { useNav } from '../utils/navigate';
 import moment from 'moment';
 import mailList from '../stores/MailList';
 import { IMessageDecodedContent } from '../indexedDB/MessagesDB';
+import { CalendarOutlined } from '@ant-design/icons';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -137,7 +138,9 @@ const MailDetail = observer(() => {
 				</div>
 				<div className='event-box'>
 					<h3 className='font-bold'>
-						Event Name
+						<span style={{ verticalAlign: 'bottom' }}>
+							<CalendarOutlined style={{ fontSize: '22px' }} />
+						</span> Event Name
 					</h3>
 					<div className='event-box-details'>
 						<table>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -50,6 +50,10 @@ const MailDetail = observer(() => {
 		}
 	})();
 
+	const downloadUrl = URL.createObjectURL(new Blob(["My amazing file!!"], {
+        type: "text/plain;charset=utf-8"
+    }));
+
 	const replyClickHandler = () => {
 		mailbox.to = message.msg.senderAddress
 			? [
@@ -152,7 +156,9 @@ const MailDetail = observer(() => {
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Event File</td>
-									<td colSpan={3}>filename.ics</td>
+									<td colSpan={3}>
+										<a href={downloadUrl} target={'_blank'} download={'my-file.txt'}>filename.ics</a>
+									</td>
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Description</td>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -14,6 +14,7 @@ import mailList from '../stores/MailList';
 import { IMessageDecodedContent } from '../indexedDB/MessagesDB';
 import { CalendarOutlined } from '@ant-design/icons';
 import { isEventFileString, parseEventFileString } from '../utils/eventFileString';
+import { formatCalendarEventDateString } from '../utils/calendarEventDate';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -172,9 +173,9 @@ const MailDetail = observer(() => {
 							<tbody>
 								<tr>
 									<td className='event-box-label font-bold'>Start</td>
-									<td>{eventData?.events[0].dtstart.value}</td>
+									<td>{formatCalendarEventDateString(eventData?.events[0].dtstart.value)}</td>
 									<td className='event-box-label font-bold'>End</td>
-									<td>{eventData?.events[0].dtend.value}</td>
+									<td>{formatCalendarEventDateString(eventData?.events[0].dtend.value)}</td>
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Where</td>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -14,6 +14,7 @@ import mailList from '../stores/MailList';
 import { IMessageDecodedContent } from '../indexedDB/MessagesDB';
 import { CalendarOutlined } from '@ant-design/icons';
 import { parseEventFileString } from '../utils/eventFileString';
+import CollapsedText from '../components/CollapsedText/CollapsedText';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -59,8 +60,6 @@ const MailDetail = observer(() => {
 
 		const eventFileBlockIndex = rawData.blocks.findIndex((item: { data: { text: string }, type: string }) => {
 			return item.type === 'calendarEvent';
-			// if (item.type !== "paragraph") return false;
-			// return isEventFileString(item.data.text);
 		});
 
 		if (eventFileBlockIndex < 0) {
@@ -186,7 +185,9 @@ const MailDetail = observer(() => {
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Description</td>
-									<td colSpan={3}>{eventData?.description}</td>
+									<td style={{whiteSpace: 'pre-line'}} colSpan={3}>
+										<CollapsedText text={eventData?.description || ''} collapseCount={250} />
+									</td>
 								</tr>
 							</tbody>
 						</table>

--- a/src/pages/MailDetail.tsx
+++ b/src/pages/MailDetail.tsx
@@ -14,7 +14,6 @@ import mailList from '../stores/MailList';
 import { IMessageDecodedContent } from '../indexedDB/MessagesDB';
 import { CalendarOutlined } from '@ant-design/icons';
 import { isEventFileString, parseEventFileString } from '../utils/eventFileString';
-import { formatCalendarEventDateString } from '../utils/calendarEventDate';
 
 const ReactEditorJS = createReactEditorJS();
 
@@ -77,7 +76,7 @@ const MailDetail = observer(() => {
 
 	})();
 
-	const downloadUrl = URL.createObjectURL(new Blob(["My amazing file!!"], {
+	const downloadUrl = URL.createObjectURL(new Blob([eventData?.originalFile || ''], {
 		type: "text/plain;charset=utf-8"
 	}));
 
@@ -166,32 +165,27 @@ const MailDetail = observer(() => {
 					<h3 className='font-bold'>
 						<span style={{ verticalAlign: 'bottom' }}>
 							<CalendarOutlined style={{ fontSize: '22px' }} />
-						</span> {eventData?.events[0].summary}
+						</span> {eventData?.summary}
 					</h3>
+					<a href={downloadUrl} target={'_blank'} download={'invite.ics'}>Download invite</a>
 					<div className='event-box-details'>
 						<table>
 							<tbody>
 								<tr>
 									<td className='event-box-label font-bold'>Start</td>
-									<td>{formatCalendarEventDateString(eventData?.events[0].dtstart.value)}</td>
+									<td>{eventData?.start}</td>
 									<td className='event-box-label font-bold'>End</td>
-									<td>{formatCalendarEventDateString(eventData?.events[0].dtend.value)}</td>
+									<td>{eventData?.end}</td>
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Where</td>
-									<td>{eventData?.events[0].location}</td>
+									<td>{eventData?.location}</td>
 									<td className='event-box-label font-bold'>Who</td>
-									<td>{eventData?.events[0].attendee?.map(person => person.EMAIL).join(', ')}</td>
-								</tr>
-								<tr>
-									<td className='event-box-label font-bold'>Event File</td>
-									<td colSpan={3}>
-										<a href={downloadUrl} target={'_blank'} download={'my-file.txt'}>filename.ics</a>
-									</td>
+									<td>{eventData?.attendees}</td>
 								</tr>
 								<tr>
 									<td className='event-box-label font-bold'>Description</td>
-									<td colSpan={3}>{eventData?.events[0].description}</td>
+									<td colSpan={3}>{eventData?.description}</td>
 								</tr>
 							</tbody>
 						</table>

--- a/src/stores/Mailbox.ts
+++ b/src/stores/Mailbox.ts
@@ -2,6 +2,7 @@ import { EVMNetwork } from '@ylide/ethereum';
 import { makeObservable, observable } from 'mobx';
 import domain from './Domain';
 import { DomainAccount } from './models/DomainAccount';
+import { ICalendarEvent } from './models/ICalendarEvent';
 
 export interface IRecipient {
 	loading: boolean;
@@ -46,12 +47,7 @@ class Mailbox {
 
 	@observable subject: string = '';
 
-	@observable event: Partial<{
-		summary: string,
-		description: string,
-		startDateTime: string,
-		endDateTime: string,
-	}> = {};
+	@observable event: Partial<ICalendarEvent> = {};
 
 	@observable textEditorData: any | null = null;
 

--- a/src/stores/Mailbox.ts
+++ b/src/stores/Mailbox.ts
@@ -9,12 +9,12 @@ export interface IRecipient {
 	type: 'contact' | 'ns' | 'address' | 'invalid';
 	address: string | null;
 	isAchievable:
-		| null
-		| false
-		| {
-				type: string;
-				blockchain: string | null;
-		  };
+	| null
+	| false
+	| {
+		type: string;
+		blockchain: string | null;
+	};
 	comment?: string;
 }
 
@@ -46,6 +46,13 @@ class Mailbox {
 
 	@observable subject: string = '';
 
+	@observable event: Partial<{
+		summary: string,
+		description: string,
+		startDateTime: string,
+		endDateTime: string,
+	}> = {};
+
 	@observable textEditorData: any | null = null;
 
 	constructor() {
@@ -58,6 +65,7 @@ class Mailbox {
 		this.to = [];
 		this.subject = '';
 		this.textEditorData = '';
+		this.event = {};
 	}
 }
 

--- a/src/stores/models/ICalendarEvent.ts
+++ b/src/stores/models/ICalendarEvent.ts
@@ -1,0 +1,7 @@
+export interface ICalendarEvent {
+    startDateTime: string,
+    endDateTime: string,
+    location: string,
+    summary?: string,
+    description?: string,
+}

--- a/src/stores/models/ICalendarEvent.ts
+++ b/src/stores/models/ICalendarEvent.ts
@@ -1,7 +1,8 @@
 export interface ICalendarEvent {
-    startDateTime: string,
-    endDateTime: string,
-    location: string,
-    summary?: string,
-    description?: string,
+    active: boolean;
+    startDateTime: string;
+    endDateTime: string;
+    location: string;
+    summary?: string;
+    description?: string;
 }

--- a/src/stores/models/ICalendarEvent.ts
+++ b/src/stores/models/ICalendarEvent.ts
@@ -1,7 +1,7 @@
 export interface ICalendarEvent {
     active: boolean;
-    startDateTime: string;
-    endDateTime: string;
+    start: Date;
+    end: Date;
     location: string;
     summary?: string;
     description?: string;

--- a/src/utils/calendarEventDate.ts
+++ b/src/utils/calendarEventDate.ts
@@ -4,6 +4,6 @@ export const createCalendarEventDateString = (date: Date) => {
     return moment.utc(date).format('YYYYMMDDTHHmmss[Z]');
 }
 
-export const parseCalendarEventDateString = (date: string) => {
-    return moment(date);
+export const formatCalendarEventDateString = (date: string) => {
+    return moment(date).format('dddd MMM DD, YYYY ⋅ HH:mma');
 }

--- a/src/utils/calendarEventDate.ts
+++ b/src/utils/calendarEventDate.ts
@@ -1,0 +1,9 @@
+import moment from "moment";
+
+export const createCalendarEventDateString = (date: Date) => {
+    return moment.utc(date).format('YYYYMMDDTHHmmss[Z]');
+}
+
+export const parseCalendarEventDateString = (date: string) => {
+    return moment(date);
+}

--- a/src/utils/calendarEventDate.ts
+++ b/src/utils/calendarEventDate.ts
@@ -7,3 +7,8 @@ export const createCalendarEventDateString = (date: Date) => {
 export const formatCalendarEventDateString = (date: string) => {
     return moment(date).format('dddd MMM DD, YYYY ⋅ HH:mma');
 }
+
+export const isValidCalendarEventDates = (startDate?: string, endDate?: string) => {
+    if (!startDate || !endDate) return false;
+    return moment(startDate).isBefore(moment(endDate));
+}

--- a/src/utils/calendarEventDate.ts
+++ b/src/utils/calendarEventDate.ts
@@ -8,7 +8,7 @@ export const formatCalendarEventDateString = (date: string) => {
     return moment(date).format('dddd MMM DD, YYYY ⋅ HH:mma');
 }
 
-export const isValidCalendarEventDates = (startDate?: string, endDate?: string) => {
+export const isValidCalendarEventDates = (startDate?: Date, endDate?: Date) => {
     if (!startDate || !endDate) return false;
     return moment(startDate).isBefore(moment(endDate));
 }

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -1,0 +1,13 @@
+import ICalParser from "ical-js-parser";
+
+const separator = "===~~~===EVENTFILE===~~~===";
+
+export const isEventFileString = (text: string) => {
+    return text.startsWith(separator) && text.endsWith(separator);
+}
+
+export const parseEventFileString = (text: string) => {
+    const eventString = text.replaceAll(separator, '').trim();
+
+    return ICalParser.toJSON(eventString);
+}

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -1,5 +1,5 @@
 import ICalParser from "ical-js-parser";
-import { createCalendarEventDateString } from "./calendarEventDate";
+import { createCalendarEventDateString, formatCalendarEventDateString } from "./calendarEventDate";
 
 const separator = "===~~~===EVENTFILE===~~~===";
 
@@ -8,9 +8,18 @@ export const isEventFileString = (text: string) => {
 }
 
 export const parseEventFileString = (text: string) => {
-    const eventString = text.replaceAll(separator, '').replaceAll('<br>', '\n').trim();
+    const eventString = text.replaceAll(separator, '').trim();
+    const result = ICalParser.toJSON(eventString);
 
-    return ICalParser.toJSON(eventString);
+    return {
+        originalFile: eventString,
+        summary: result.events[0].summary,
+        description: result.events[0].description,
+        location: result.events[0].location,
+        start: formatCalendarEventDateString(result.events[0].dtstart.value),
+        end: formatCalendarEventDateString(result.events[0].dtend.value),
+        attendees: result.events[0].attendee?.map(person => person.EMAIL).join(', '),
+    }
 }
 
 export const createEventFileString = ({

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -18,16 +18,16 @@ export const parseEventFileString = (text: string) => {
 export const createEventFileString = ({
     organizer,
     attendees,
-    startDateTime,
-    endDateTime,
+    start,
+    end,
     summary,
     description,
     locaiton
 }: {
     organizer: string,
     attendees: string[],
-    startDateTime: Date,
-    endDateTime: Date,
+    start: Date,
+    end: Date,
     summary: string,
     description: string,
     locaiton: string,
@@ -53,10 +53,10 @@ export const createEventFileString = ({
                     description: description,
                     locaiton: locaiton,
                     dtstart: {
-                        value: createCalendarEventDateString(startDateTime)
+                        value: createCalendarEventDateString(start)
                     },
                     dtend: {
-                        value: createCalendarEventDateString(endDateTime)
+                        value: createCalendarEventDateString(end)
                     },
                     organizer: {
                         EMAIL: organizer,

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -7,7 +7,7 @@ export const parseEventFileString = (text: string) => {
     return {
         originalFile: text,
         summary: result.events[0].summary,
-        description: result.events[0].description,
+        description: result.events[0].description?.replaceAll('\\n', '\n'),
         location: result.events[0].location,
         start: formatCalendarEventDateString(result.events[0].dtstart.value),
         end: formatCalendarEventDateString(result.events[0].dtend.value),

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -1,18 +1,11 @@
 import ICalParser from "ical-js-parser";
 import { createCalendarEventDateString, formatCalendarEventDateString } from "./calendarEventDate";
 
-const separator = "===~~~===EVENTFILE===~~~===";
-
-export const isEventFileString = (text: string) => {
-    return text.startsWith(separator) && text.endsWith(separator);
-}
-
 export const parseEventFileString = (text: string) => {
-    const eventString = text.replaceAll(separator, '').trim();
-    const result = ICalParser.toJSON(eventString);
+    const result = ICalParser.toJSON(text);
 
     return {
-        originalFile: eventString,
+        originalFile: text,
         summary: result.events[0].summary,
         description: result.events[0].description,
         location: result.events[0].location,
@@ -82,5 +75,5 @@ export const createEventFileString = ({
     }
 
     const resultString = ICalParser.toString(eventData);
-    return `${separator}\n${resultString}\n${separator}`;
+    return resultString;
 }

--- a/src/utils/eventFileString.ts
+++ b/src/utils/eventFileString.ts
@@ -1,4 +1,5 @@
 import ICalParser from "ical-js-parser";
+import { createCalendarEventDateString } from "./calendarEventDate";
 
 const separator = "===~~~===EVENTFILE===~~~===";
 
@@ -7,7 +8,70 @@ export const isEventFileString = (text: string) => {
 }
 
 export const parseEventFileString = (text: string) => {
-    const eventString = text.replaceAll(separator, '').trim();
+    const eventString = text.replaceAll(separator, '').replaceAll('<br>', '\n').trim();
 
     return ICalParser.toJSON(eventString);
+}
+
+export const createEventFileString = ({
+    organizer,
+    attendees,
+    startDateTime,
+    endDateTime,
+    summary,
+    description,
+    locaiton
+}: {
+    organizer: string,
+    attendees: string[],
+    startDateTime: Date,
+    endDateTime: Date,
+    summary: string,
+    description: string,
+    locaiton: string,
+}) => {
+    const eventData = {
+        calendar:
+        {
+            begin: 'VCALENDAR',
+            prodid: 'Ylide',
+            version: '1',
+            end: 'VCALENDAR',
+            method: 'REQUEST'
+        },
+        events:
+            [
+                {
+                    begin: 'VEVENT',
+                    dtstamp: {
+                        value: createCalendarEventDateString(new Date())
+                    },
+                    uid: `ylide-${Date.now()}-${Math.round(Math.random() * 10000)}`,
+                    summary: summary,
+                    description: description,
+                    locaiton: locaiton,
+                    dtstart: {
+                        value: createCalendarEventDateString(startDateTime)
+                    },
+                    dtend: {
+                        value: createCalendarEventDateString(endDateTime)
+                    },
+                    organizer: {
+                        EMAIL: organizer,
+                        mailto: organizer
+                    },
+                    attendee: attendees.map(attendee => ({
+                        CUTYPE: "INDIVIDUAL",
+                        ROLE: "REQ-PARTICIPANT",
+                        EMAIL: attendee,
+                        mailto: attendee,
+                    })),
+                    sequence: '1',
+                    end: 'VEVENT',
+                }
+            ]
+    }
+
+    const resultString = ICalParser.toString(eventData);
+    return `${separator}\n${resultString}\n${separator}`;
 }


### PR DESCRIPTION
**Note:** This MR is my submission to the [Ylide mini-products and utilities bounty](https://gitcoin.co/issue/29559)

# Summary

Add calendar events to the email. This is done by injecting a block with type `"calendarEvent"` to the blocks of the editor before sending the transaction. When the mail is received, we extract this `"calendarEvent"` block and display the event in its own section.

The `"calendarEvent"` block will be the text of an ics file. This means that it is a legit calendar event, and can be downloaded and imported in the users' calendars.

# UX Flow

![image](https://user-images.githubusercontent.com/23722804/201989705-059b6ea5-b6bd-4932-99c3-5e0e22740652.png)

---

![image](https://user-images.githubusercontent.com/23722804/201989849-74d7013d-61d0-4268-a099-04dec612fa71.png)

---

![image](https://user-images.githubusercontent.com/23722804/201990111-6057c46d-601f-4da3-be9c-cdece716b38f.png)

---

![image](https://user-images.githubusercontent.com/23722804/201990572-ee6e256e-210b-4c05-8c89-4e5b3b417a06.png)
