### PR TITLE
Feature/account qrcode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"react-dom": "^17.0.2",
 				"react-editor-js": "^2.0.6",
 				"react-infinite-scroll-component": "^6.1.0",
+				"react-qrcode-logo": "^2.8.0",
 				"react-router-dom": "^6.3.0",
 				"react-select": "^5.3.2",
 				"react-svg": "^15.0.3",
@@ -4624,227 +4625,6 @@
 				"string.prototype.matchall": "^4.0.6"
 			}
 		},
-		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
-			"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
-			"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
-			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
-			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
-			"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
-			"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
-			"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
-			"integrity": "sha512-q4jSH1UUvbrsOtlo/tKcgSeiCHRSBdXoIoqX1pgcKK/aU3JD27wmMKwGtpB8qRYUYoyXvfGxUVKchLuR5pB3rQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-preset": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
-			"integrity": "sha512-4FiXBjvQ+z2j7yASeGPEi8VD/5rrGQk4Xrq3EdJmoZgz/tpqChpo5hgXDvmEauwtvOc52q8ghhZK4Oy7qph4ig==",
-			"dev": true,
-			"dependencies": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
-				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
-				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/core": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.5.0.tgz",
-			"integrity": "sha512-q52VOcsJPvV3jO1wkPtzTuKlvX7Y3xIcWRpCMtBF3MrteZJtBfQw/+u0B1BHy5ColpQc1/YVTrPEtSYIMNZlrQ==",
-			"dev": true,
-			"dependencies": {
-				"@svgr/plugin-jsx": "^5.5.0",
-				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/hast-util-to-babel-ast": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
-			"integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.12.6"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/plugin-jsx": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
-			"integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@svgr/babel-preset": "^5.5.0",
-				"@svgr/hast-util-to-babel-ast": "^5.5.0",
-				"svg-parser": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/plugin-svgo": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
-			"integrity": "sha512-r5swKk46GuQl4RrVejVwpeeJaydoxkdwkM1mBKOgJLBUJPGaLci6ylg/IjhrRsREKDkr4kbMWdgOtbXEh0fyLQ==",
-			"dev": true,
-			"dependencies": {
-				"cosmiconfig": "^7.0.0",
-				"deepmerge": "^4.2.2",
-				"svgo": "^1.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/webpack": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
-			"integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/plugin-transform-react-constant-elements": "^7.12.1",
-				"@babel/preset-env": "^7.12.1",
-				"@babel/preset-react": "^7.12.5",
-				"@svgr/core": "^5.5.0",
-				"@svgr/plugin-jsx": "^5.5.0",
-				"@svgr/plugin-svgo": "^5.5.0",
-				"loader-utils": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -8914,12 +8694,12 @@
 			"dev": true
 		},
 		"node_modules/css-tree": {
-			"version": "1.0.0-alpha.37",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
-			"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
 			"dev": true,
 			"dependencies": {
-				"mdn-data": "2.0.4",
+				"mdn-data": "2.0.14",
 				"source-map": "^0.6.1"
 			},
 			"engines": {
@@ -9055,34 +8835,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/csso/node_modules/css-tree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-			"dev": true,
-			"dependencies": {
-				"mdn-data": "2.0.14",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/csso/node_modules/mdn-data": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-			"dev": true
-		},
-		"node_modules/csso/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cssom": {
@@ -16377,6 +16129,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -16514,9 +16271,9 @@
 			}
 		},
 		"node_modules/mdn-data": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
 			"dev": true
 		},
 		"node_modules/media-typer": {
@@ -19178,64 +18935,6 @@
 				"postcss": "^8.2.15"
 			}
 		},
-		"node_modules/postcss-svgo/node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/postcss-svgo/node_modules/css-tree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-			"dev": true,
-			"dependencies": {
-				"mdn-data": "2.0.14",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/postcss-svgo/node_modules/mdn-data": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-			"dev": true
-		},
-		"node_modules/postcss-svgo/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/postcss-svgo/node_modules/svgo": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-			"dev": true,
-			"dependencies": {
-				"@trysound/sax": "0.2.0",
-				"commander": "^7.2.0",
-				"css-select": "^4.1.3",
-				"css-tree": "^1.1.3",
-				"csso": "^4.2.0",
-				"picocolors": "^1.0.0",
-				"stable": "^0.1.8"
-			},
-			"bin": {
-				"svgo": "bin/svgo"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/postcss-unique-selectors": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
@@ -19475,6 +19174,11 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/qrcode-generator": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+			"integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
 		},
 		"node_modules/qrcode/node_modules/buffer": {
 			"version": "5.7.1",
@@ -20451,6 +20155,19 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
+		"node_modules/react-qrcode-logo": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/react-qrcode-logo/-/react-qrcode-logo-2.8.0.tgz",
+			"integrity": "sha512-dbEgjsg6C4tK6+oGmCRDlJ7urQAWqybaGBLJtp8Z6ZYvVUP302HBXk/F7VRk54yWTwzlHwig3VK6HMKCha2YFw==",
+			"dependencies": {
+				"lodash.isequal": "^4.5.0",
+				"qrcode-generator": "^1.4.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.1",
+				"react-dom": ">=16.4.1"
+			}
+		},
 		"node_modules/react-refresh": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -20563,6 +20280,305 @@
 				}
 			}
 		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-add-jsx-attribute": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+			"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+			"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-svg-dynamic-title": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+			"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-svg-em-dimensions": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+			"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-transform-react-native-svg": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+			"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-plugin-transform-svg-component": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
+			"integrity": "sha512-q4jSH1UUvbrsOtlo/tKcgSeiCHRSBdXoIoqX1pgcKK/aU3JD27wmMKwGtpB8qRYUYoyXvfGxUVKchLuR5pB3rQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/babel-preset": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
+			"integrity": "sha512-4FiXBjvQ+z2j7yASeGPEi8VD/5rrGQk4Xrq3EdJmoZgz/tpqChpo5hgXDvmEauwtvOc52q8ghhZK4Oy7qph4ig==",
+			"dev": true,
+			"dependencies": {
+				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/core": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.5.0.tgz",
+			"integrity": "sha512-q52VOcsJPvV3jO1wkPtzTuKlvX7Y3xIcWRpCMtBF3MrteZJtBfQw/+u0B1BHy5ColpQc1/YVTrPEtSYIMNZlrQ==",
+			"dev": true,
+			"dependencies": {
+				"@svgr/plugin-jsx": "^5.5.0",
+				"camelcase": "^6.2.0",
+				"cosmiconfig": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/hast-util-to-babel-ast": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
+			"integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.12.6"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/plugin-jsx": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
+			"integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.12.3",
+				"@svgr/babel-preset": "^5.5.0",
+				"@svgr/hast-util-to-babel-ast": "^5.5.0",
+				"svg-parser": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/plugin-svgo": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
+			"integrity": "sha512-r5swKk46GuQl4RrVejVwpeeJaydoxkdwkM1mBKOgJLBUJPGaLci6ylg/IjhrRsREKDkr4kbMWdgOtbXEh0fyLQ==",
+			"dev": true,
+			"dependencies": {
+				"cosmiconfig": "^7.0.0",
+				"deepmerge": "^4.2.2",
+				"svgo": "^1.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/@svgr/webpack": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
+			"integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.12.3",
+				"@babel/plugin-transform-react-constant-elements": "^7.12.1",
+				"@babel/preset-env": "^7.12.1",
+				"@babel/preset-react": "^7.12.5",
+				"@svgr/core": "^5.5.0",
+				"@svgr/plugin-jsx": "^5.5.0",
+				"@svgr/plugin-svgo": "^5.5.0",
+				"loader-utils": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/react-scripts/node_modules/css-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+			"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^3.2.1",
+				"domutils": "^1.7.0",
+				"nth-check": "^1.0.2"
+			}
+		},
+		"node_modules/react-scripts/node_modules/css-tree": {
+			"version": "1.0.0-alpha.37",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+			"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.4",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/react-scripts/node_modules/css-what": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/react-scripts/node_modules/dom-serializer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			}
+		},
+		"node_modules/react-scripts/node_modules/domutils": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/react-scripts/node_modules/domutils/node_modules/domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true
+		},
+		"node_modules/react-scripts/node_modules/mdn-data": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"dev": true
+		},
+		"node_modules/react-scripts/node_modules/nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "~1.0.0"
+			}
+		},
 		"node_modules/react-scripts/node_modules/semver": {
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -20576,6 +20592,43 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/react-scripts/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-scripts/node_modules/svgo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+			"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+			"deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
+				"css-select": "^2.0.0",
+				"css-select-base-adapter": "^0.1.1",
+				"css-tree": "1.0.0-alpha.37",
+				"csso": "^4.0.2",
+				"js-yaml": "^3.13.1",
+				"mkdirp": "~0.5.1",
+				"object.values": "^1.1.0",
+				"sax": "~1.2.4",
+				"stable": "^0.1.8",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
+			},
+			"bin": {
+				"svgo": "bin/svgo"
+			},
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/react-select": {
@@ -22649,90 +22702,33 @@
 			"dev": true
 		},
 		"node_modules/svgo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
-			"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
-			"deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
 			"dev": true,
 			"dependencies": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^4.1.3",
+				"css-tree": "^1.1.3",
+				"csso": "^4.2.0",
+				"picocolors": "^1.0.0",
+				"stable": "^0.1.8"
 			},
 			"bin": {
 				"svgo": "bin/svgo"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/svgo/node_modules/css-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-			"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-			"dev": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
-			}
-		},
-		"node_modules/svgo/node_modules/css-what": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+		"node_modules/svgo/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/svgo/node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			}
-		},
-		"node_modules/svgo/node_modules/domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-			"dev": true,
-			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
-		"node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true
-		},
-		"node_modules/svgo/node_modules/nth-check": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-			"dev": true,
-			"dependencies": {
-				"boolbase": "~1.0.0"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/swarm-js": {
@@ -28563,129 +28559,6 @@
 				"string.prototype.matchall": "^4.0.6"
 			}
 		},
-		"@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
-			"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
-			"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
-			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
-			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
-			"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
-			"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
-			"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
-			"dev": true
-		},
-		"@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
-			"integrity": "sha512-q4jSH1UUvbrsOtlo/tKcgSeiCHRSBdXoIoqX1pgcKK/aU3JD27wmMKwGtpB8qRYUYoyXvfGxUVKchLuR5pB3rQ==",
-			"dev": true
-		},
-		"@svgr/babel-preset": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
-			"integrity": "sha512-4FiXBjvQ+z2j7yASeGPEi8VD/5rrGQk4Xrq3EdJmoZgz/tpqChpo5hgXDvmEauwtvOc52q8ghhZK4Oy7qph4ig==",
-			"dev": true,
-			"requires": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
-				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
-				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
-			}
-		},
-		"@svgr/core": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.5.0.tgz",
-			"integrity": "sha512-q52VOcsJPvV3jO1wkPtzTuKlvX7Y3xIcWRpCMtBF3MrteZJtBfQw/+u0B1BHy5ColpQc1/YVTrPEtSYIMNZlrQ==",
-			"dev": true,
-			"requires": {
-				"@svgr/plugin-jsx": "^5.5.0",
-				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.0"
-			}
-		},
-		"@svgr/hast-util-to-babel-ast": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
-			"integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.12.6"
-			}
-		},
-		"@svgr/plugin-jsx": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
-			"integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.12.3",
-				"@svgr/babel-preset": "^5.5.0",
-				"@svgr/hast-util-to-babel-ast": "^5.5.0",
-				"svg-parser": "^2.0.2"
-			}
-		},
-		"@svgr/plugin-svgo": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
-			"integrity": "sha512-r5swKk46GuQl4RrVejVwpeeJaydoxkdwkM1mBKOgJLBUJPGaLci6ylg/IjhrRsREKDkr4kbMWdgOtbXEh0fyLQ==",
-			"dev": true,
-			"requires": {
-				"cosmiconfig": "^7.0.0",
-				"deepmerge": "^4.2.2",
-				"svgo": "^1.2.2"
-			}
-		},
-		"@svgr/webpack": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
-			"integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.12.3",
-				"@babel/plugin-transform-react-constant-elements": "^7.12.1",
-				"@babel/preset-env": "^7.12.1",
-				"@babel/preset-react": "^7.12.5",
-				"@svgr/core": "^5.5.0",
-				"@svgr/plugin-jsx": "^5.5.0",
-				"@svgr/plugin-svgo": "^5.5.0",
-				"loader-utils": "^2.0.0"
-			}
-		},
 		"@szmarczak/http-timer": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -32015,12 +31888,12 @@
 			"dev": true
 		},
 		"css-tree": {
-			"version": "1.0.0-alpha.37",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
-			"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
 			"dev": true,
 			"requires": {
-				"mdn-data": "2.0.4",
+				"mdn-data": "2.0.14",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
@@ -32112,30 +31985,6 @@
 			"dev": true,
 			"requires": {
 				"css-tree": "^1.1.2"
-			},
-			"dependencies": {
-				"css-tree": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-					"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-					"dev": true,
-					"requires": {
-						"mdn-data": "2.0.14",
-						"source-map": "^0.6.1"
-					}
-				},
-				"mdn-data": {
-					"version": "2.0.14",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"cssom": {
@@ -37801,6 +37650,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -37923,9 +37777,9 @@
 			}
 		},
 		"mdn-data": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
 			"dev": true
 		},
 		"media-typer": {
@@ -39718,51 +39572,6 @@
 			"requires": {
 				"postcss-value-parser": "^4.2.0",
 				"svgo": "^2.7.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-					"dev": true
-				},
-				"css-tree": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-					"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-					"dev": true,
-					"requires": {
-						"mdn-data": "2.0.14",
-						"source-map": "^0.6.1"
-					}
-				},
-				"mdn-data": {
-					"version": "2.0.14",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"svgo": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-					"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-					"dev": true,
-					"requires": {
-						"@trysound/sax": "0.2.0",
-						"commander": "^7.2.0",
-						"css-select": "^4.1.3",
-						"css-tree": "^1.1.3",
-						"csso": "^4.2.0",
-						"picocolors": "^1.0.0",
-						"stable": "^0.1.8"
-					}
-				}
 			}
 		},
 		"postcss-unique-selectors": {
@@ -39961,6 +39770,11 @@
 					}
 				}
 			}
+		},
+		"qrcode-generator": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+			"integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
 		},
 		"qs": {
 			"version": "6.11.0",
@@ -40639,6 +40453,15 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
+		"react-qrcode-logo": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/react-qrcode-logo/-/react-qrcode-logo-2.8.0.tgz",
+			"integrity": "sha512-dbEgjsg6C4tK6+oGmCRDlJ7urQAWqybaGBLJtp8Z6ZYvVUP302HBXk/F7VRk54yWTwzlHwig3VK6HMKCha2YFw==",
+			"requires": {
+				"lodash.isequal": "^4.5.0",
+				"qrcode-generator": "^1.4.1"
+			}
+		},
 		"react-refresh": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -40718,6 +40541,200 @@
 				"workbox-webpack-plugin": "^6.4.1"
 			},
 			"dependencies": {
+				"@svgr/babel-plugin-add-jsx-attribute": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+					"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-remove-jsx-attribute": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+					"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-remove-jsx-empty-expression": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+					"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-replace-jsx-attribute-value": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+					"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-svg-dynamic-title": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+					"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-svg-em-dimensions": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+					"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-transform-react-native-svg": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+					"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q==",
+					"dev": true
+				},
+				"@svgr/babel-plugin-transform-svg-component": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
+					"integrity": "sha512-q4jSH1UUvbrsOtlo/tKcgSeiCHRSBdXoIoqX1pgcKK/aU3JD27wmMKwGtpB8qRYUYoyXvfGxUVKchLuR5pB3rQ==",
+					"dev": true
+				},
+				"@svgr/babel-preset": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
+					"integrity": "sha512-4FiXBjvQ+z2j7yASeGPEi8VD/5rrGQk4Xrq3EdJmoZgz/tpqChpo5hgXDvmEauwtvOc52q8ghhZK4Oy7qph4ig==",
+					"dev": true,
+					"requires": {
+						"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+						"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+						"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+						"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+						"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+						"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+						"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+						"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
+					}
+				},
+				"@svgr/core": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.5.0.tgz",
+					"integrity": "sha512-q52VOcsJPvV3jO1wkPtzTuKlvX7Y3xIcWRpCMtBF3MrteZJtBfQw/+u0B1BHy5ColpQc1/YVTrPEtSYIMNZlrQ==",
+					"dev": true,
+					"requires": {
+						"@svgr/plugin-jsx": "^5.5.0",
+						"camelcase": "^6.2.0",
+						"cosmiconfig": "^7.0.0"
+					}
+				},
+				"@svgr/hast-util-to-babel-ast": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
+					"integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.6"
+					}
+				},
+				"@svgr/plugin-jsx": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
+					"integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.12.3",
+						"@svgr/babel-preset": "^5.5.0",
+						"@svgr/hast-util-to-babel-ast": "^5.5.0",
+						"svg-parser": "^2.0.2"
+					}
+				},
+				"@svgr/plugin-svgo": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
+					"integrity": "sha512-r5swKk46GuQl4RrVejVwpeeJaydoxkdwkM1mBKOgJLBUJPGaLci6ylg/IjhrRsREKDkr4kbMWdgOtbXEh0fyLQ==",
+					"dev": true,
+					"requires": {
+						"cosmiconfig": "^7.0.0",
+						"deepmerge": "^4.2.2",
+						"svgo": "^1.2.2"
+					}
+				},
+				"@svgr/webpack": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
+					"integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.12.3",
+						"@babel/plugin-transform-react-constant-elements": "^7.12.1",
+						"@babel/preset-env": "^7.12.1",
+						"@babel/preset-react": "^7.12.5",
+						"@svgr/core": "^5.5.0",
+						"@svgr/plugin-jsx": "^5.5.0",
+						"@svgr/plugin-svgo": "^5.5.0",
+						"loader-utils": "^2.0.0"
+					}
+				},
+				"css-select": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+					"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0",
+						"css-what": "^3.2.1",
+						"domutils": "^1.7.0",
+						"nth-check": "^1.0.2"
+					}
+				},
+				"css-tree": {
+					"version": "1.0.0-alpha.37",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+					"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "2.0.4",
+						"source-map": "^0.6.1"
+					}
+				},
+				"css-what": {
+					"version": "3.4.2",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+					"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+					"dev": true
+				},
+				"dom-serializer": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+					"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"entities": "^2.0.0"
+					}
+				},
+				"domutils": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					},
+					"dependencies": {
+						"domelementtype": {
+							"version": "1.3.1",
+							"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+							"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+							"dev": true
+						}
+					}
+				},
+				"mdn-data": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+					"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+					"dev": true
+				},
+				"nth-check": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+					"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+					"dev": true,
+					"requires": {
+						"boolbase": "~1.0.0"
+					}
+				},
 				"semver": {
 					"version": "7.3.8",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -40725,6 +40742,33 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"svgo": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+					"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"coa": "^2.0.2",
+						"css-select": "^2.0.0",
+						"css-select-base-adapter": "^0.1.1",
+						"css-tree": "1.0.0-alpha.37",
+						"csso": "^4.0.2",
+						"js-yaml": "^3.13.1",
+						"mkdirp": "~0.5.1",
+						"object.values": "^1.1.0",
+						"sax": "~1.2.4",
+						"stable": "^0.1.8",
+						"unquote": "~1.1.1",
+						"util.promisify": "~1.0.0"
 					}
 				}
 			}
@@ -42352,80 +42396,25 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
-			"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^4.1.3",
+				"css-tree": "^1.1.3",
+				"csso": "^4.2.0",
+				"picocolors": "^1.0.0",
+				"stable": "^0.1.8"
 			},
 			"dependencies": {
-				"css-select": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-					"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-					"dev": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^3.2.1",
-						"domutils": "^1.7.0",
-						"nth-check": "^1.0.2"
-					}
-				},
-				"css-what": {
-					"version": "3.4.2",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-					"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+				"commander": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 					"dev": true
-				},
-				"dom-serializer": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-					"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^2.0.1",
-						"entities": "^2.0.0"
-					}
-				},
-				"domutils": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					},
-					"dependencies": {
-						"domelementtype": {
-							"version": "1.3.1",
-							"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-							"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-							"dev": true
-						}
-					}
-				},
-				"nth-check": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-					"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-					"dev": true,
-					"requires": {
-						"boolbase": "~1.0.0"
-					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"react-dom": "^17.0.2",
 		"react-editor-js": "^2.0.6",
 		"react-infinite-scroll-component": "^6.1.0",
+		"react-qrcode-logo": "^2.8.0",
 		"react-router-dom": "^6.3.0",
 		"react-select": "^5.3.2",
 		"react-svg": "^15.0.3",

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,6 +9,7 @@ import {
 	MenuFoldOutlined,
 	MenuUnfoldOutlined,
 	PlusOutlined,
+	QrcodeOutlined,
 	UsergroupAddOutlined,
 } from '@ant-design/icons';
 import { observer } from 'mobx-react';
@@ -19,6 +20,7 @@ import { walletsMap } from '../../constants';
 import { useWindowSize } from '../../utils/useWindowSize';
 import modals from '../../stores/Modals';
 import { AdaptiveAddress } from '../../controls/AdaptiveAddress';
+import QrModal from '../../modals/QrModal';
 
 const AccountItem = observer(({ account }: { account: DomainAccount }) => {
 	const nav = useNav();
@@ -56,6 +58,14 @@ const AccountItem = observer(({ account }: { account: DomainAccount }) => {
 				</div>
 			</div>
 			<div className="ali-actions">
+				<Tooltip title="Share your Ylide!">
+					<Button
+						icon={<QrcodeOutlined />}
+						onClick={() => {
+							QrModal.show(account.account.address);
+						}}
+					/>
+				</Tooltip>
 				<Tooltip title="Logout">
 					<Button
 						danger

--- a/src/modals/QrModal/index.tsx
+++ b/src/modals/QrModal/index.tsx
@@ -1,0 +1,56 @@
+import { PureComponent } from 'react';
+import { observer } from 'mobx-react';
+import { QRCode } from 'react-qrcode-logo';
+
+import modals from '../../stores/Modals';
+import YlideModal from '../YlideModal';
+
+export interface QrModalProps {
+	title?: string;
+	subtitle?: string;
+	content?: string;
+	onResolve: () => void;
+}
+
+@observer
+export default class QrModal extends PureComponent<QrModalProps> {
+	static async show(content?: string): Promise<void> {
+		return new Promise<void>((resolve) => {
+			modals.show((close: () => void) => (
+				<QrModal
+					title={'Share your Ylide!'}
+					subtitle={'Your scannable address'}
+					content={content}
+					onResolve={() => {
+						close();
+						resolve();
+					}}
+				/>
+			));
+		});
+	}
+
+	render() {
+		return (
+			<YlideModal
+				title={this.props.title}
+				subtitle={this.props.subtitle}
+				cancelContent={null}
+				confirmContent={'Close'}
+				onConfirm={() => {
+					this.props.onResolve();
+				}}
+			>
+				<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}>
+					<QRCode
+						eyeRadius={2}
+						logoImage='/favicon-96x96.png'
+						logoOpacity={0.8}
+						qrStyle='dots'
+						value={this.props.content}
+					/>
+				</div>
+			</YlideModal>
+		);
+	}
+}


### PR DESCRIPTION
This PR is made in the context of Gitcoin's Everscale Hackathon for the _[Mini-products and Utilities Bounty](https://gitcoin.co/issue/29559)_.

It allows to generate a scannable QR code to share one's address on Ylide.

A subsequent PR is planned to:
- Add a QS parameter for `/compose` route
- QR code directs to `/compose` + added QS for recipient (_to:_) field


Preview screenshot:
![image](https://user-images.githubusercontent.com/1357711/203599587-98294d1f-0182-4b22-bbbe-f6f47fe4358f.png)
